### PR TITLE
Exclude namespaces for embedded schemas if they are the same as root schema namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ $merger->merge();
 
 ### Generating schemas from classes
 Please note, that this feature is highly experimental.  
-You probably still need to adjust the generated templates, but it gives you a basic tempalte to work with.  
-Class direcotries: Directories containing the classes you want to generate schemas from
+You probably still need to adjust the generated templates, but it gives you a basic template to work with.  
+Class directories: Directories containing the classes you want to generate schemas from
 Output directory: output directory for your generated schema templates
 
 #### Generate schemas (code)

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -98,11 +98,12 @@ final class SchemaMerger implements SchemaMergerInterface
     ): string {
         $idString = '"' . $schemaId . '"';
 
+        $embeddedDefinition = $this->excludeNamespacesForEmbeddedSchema($definition, $embeddedDefinition);
+
         $pos = strpos($definition, $idString);
 
         return substr_replace($definition, $embeddedDefinition, $pos, strlen($idString));
     }
-
 
     /**
      * @param boolean $prefixWithNamespace
@@ -175,5 +176,27 @@ final class SchemaMerger implements SchemaMergerInterface
         unset($schemaDefinition['schema_level']);
 
         return $schemaDefinition;
+    }
+
+    /**
+     * @param string $definition
+     * @param string $embeddedDefinition
+     * @return string
+     */
+    private function excludeNamespacesForEmbeddedSchema(string $definition, string $embeddedDefinition): string
+    {
+        $decodedRootDefinition = json_decode($definition, true);
+        $decodedEmbeddedDefinition = json_decode($embeddedDefinition, true);
+
+        if (
+            isset($decodedRootDefinition['namespace']) && isset($decodedEmbeddedDefinition['namespace']) &&
+            $decodedRootDefinition['namespace'] === $decodedEmbeddedDefinition['namespace']
+        ) {
+            unset($decodedEmbeddedDefinition['namespace']);
+            /** @var string $embeddedDefinition */
+            $embeddedDefinition = json_encode($decodedEmbeddedDefinition);
+        }
+
+        return $embeddedDefinition;
     }
 }


### PR DESCRIPTION
According to `flix-tech/avro-php` library when schema (after merging with `avro:subschema:merge`) is parsed it will not contain namespaces for embedded schemas if they are the same as root schema namespace.

I suggest this (or similar) change to follow the same behaviour.