### PR TITLE
Exclude namespaces for embedded schemas if they are the same as root schema namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ $merger->merge();
 
 ### Generating schemas from classes
 Please note, that this feature is highly experimental.  
-You probably still need to adjust the generated templates, but it gives you a basic tempalte to work with.  
-Class direcotries: Directories containing the classes you want to generate schemas from
+You probably still need to adjust the generated templates, but it gives you a basic template to work with.  
+Class directories: Directories containing the classes you want to generate schemas from
 Output directory: output directory for your generated schema templates
 
 #### Generate schemas (code)

--- a/src/Command/SubSchemaMergeCommand.php
+++ b/src/Command/SubSchemaMergeCommand.php
@@ -29,6 +29,12 @@ class SubSchemaMergeCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Use template filename as schema filename'
+            )
+            ->addOption(
+                'optimizeSubSchemaNamespaces',
+                null,
+                InputOption::VALUE_NONE,
+                'Exclude namespaces from embedded entities if they are different than root schema namespace'
             );
     }
 
@@ -52,9 +58,9 @@ class SubSchemaMergeCommand extends Command
 
         $result = $merger->merge(
             (bool) $input->getOption('prefixWithNamespace'),
-            (bool) $input->getOption('useFilenameAsSchemaName')
+            (bool) $input->getOption('useFilenameAsSchemaName'),
+            (bool) $input->getOption('optimizeSubSchemaNamespaces')
         );
-
 
         // retrieve the argument value using getArgument()
         $output->writeln(sprintf('Merged %d root schema files', $result));

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -98,11 +98,12 @@ final class SchemaMerger implements SchemaMergerInterface
     ): string {
         $idString = '"' . $schemaId . '"';
 
+        $embeddedDefinition = $this->excludeNamespacesForEmbeddedSchema($definition, $embeddedDefinition);
+
         $pos = strpos($definition, $idString);
 
         return substr_replace($definition, $embeddedDefinition, $pos, strlen($idString));
     }
-
 
     /**
      * @param boolean $prefixWithNamespace
@@ -175,5 +176,27 @@ final class SchemaMerger implements SchemaMergerInterface
         unset($schemaDefinition['schema_level']);
 
         return $schemaDefinition;
+    }
+
+    /**
+     * @param string $definition
+     * @param string $embeddedDefinition
+     * @return string
+     */
+    private function excludeNamespacesForEmbeddedSchema(string $definition, string $embeddedDefinition): string
+    {
+        $decodedRootDefinition = json_decode($definition, true);
+        $decodedEmbeddedDefinition = json_decode($embeddedDefinition, true);
+
+        if (
+            isset($decodedRootDefinition['namespace']) && isset($decodedEmbeddedDefinition['namespace']) &&
+            $decodedRootDefinition['namespace'] === $decodedEmbeddedDefinition['namespace']
+        ) {
+            unset($decodedEmbeddedDefinition['namespace']);
+            /** @var string $embeddedDefinition */
+            $embeddedDefinition = json_encode($decodedEmbeddedDefinition);
+        }
+
+        return $embeddedDefinition;
     }
 }

--- a/tests/Unit/Merger/SchemaMergerTest.php
+++ b/tests/Unit/Merger/SchemaMergerTest.php
@@ -92,7 +92,14 @@ class SchemaMergerTest extends TestCase
             ]
         }';
 
-        $expectedResult = str_replace('"com.example.Page"', $subschemaDefinition, $rootDefinition);
+        $expectedResult = '{
+            "type": "record",
+            "namespace": "com.example",
+            "name": "Book",
+            "fields": [
+                { "name": "items", "type": {"type": "array", "items": {"type":"record","name":"Page","fields":[{"name":"number","type":"int"}]} }, "default": [] }
+            ]
+        }';
 
         $subschemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
         $subschemaTemplate
@@ -116,6 +123,55 @@ class SchemaMergerTest extends TestCase
             ->with($expectedResult)
             ->willReturn($rootSchemaTemplate);
 
+        $merger = new SchemaMerger($schemaRegistry);
+
+        $merger->getResolvedSchemaTemplate($rootSchemaTemplate);
+    }
+
+    public function testGetResolvedSchemaTemplateWithDifferentNamespaceForEmbeddedSchema()
+    {
+        $rootDefinition = '{
+            "type": "record",
+            "namespace": "com.example",
+            "name": "Book",
+            "fields": [
+                { "name": "items", "type": {"type": "array", "items": "com.example.other.Page" }, "default": [] }
+            ]
+        }';
+        $subschemaDefinition = '{
+            "type": "record",
+            "namespace": "com.example.other",
+            "name": "Page",
+            "fields": [
+                { "name": "number", "type": "int" }
+            ]
+        }';
+
+        $expectedResult = str_replace('"com.example.other.Page"', $subschemaDefinition, $rootDefinition);
+
+        $subschemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
+        $subschemaTemplate
+            ->expects(self::once())
+            ->method('getSchemaDefinition')
+            ->willReturn($subschemaDefinition);
+
+        $schemaRegistry = $this->getMockForAbstractClass(SchemaRegistryInterface::class);
+        $schemaRegistry
+            ->expects(self::once())
+            ->method('getSchemaById')
+            ->with('com.example.other.Page')
+            ->willReturn($subschemaTemplate);
+
+        $rootSchemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
+        $rootSchemaTemplate
+            ->expects(self::once())
+            ->method('getSchemaDefinition')
+            ->willReturn($rootDefinition);
+        $rootSchemaTemplate
+            ->expects(self::once())
+            ->method('withSchemaDefinition')
+            ->with($expectedResult)
+            ->willReturn($rootSchemaTemplate);
 
         $merger = new SchemaMerger($schemaRegistry);
 


### PR DESCRIPTION
According to `flix-tech/avro-php` library when schema (after merging with `avro:subschema:merge`) is parsed it will not contain namespaces for embedded schemas if they are the same as root schema namespace.

I suggest this (or similar) change to follow the same behaviour.