### PR TITLE
Exclude namespace in type and items

### DIFF
--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -132,7 +132,12 @@ final class SchemaMerger implements SchemaMergerInterface
             } catch (SchemaMergerException $e) {
                 throw $e;
             }
-            $this->exportSchema($resolvedTemplate, $prefixWithNamespace, $useTemplateName);
+            $this->exportSchema(
+                $resolvedTemplate,
+                $prefixWithNamespace,
+                $useTemplateName,
+                $optimizeSubSchemaNamespaces
+            );
             ++$mergedFiles;
         }
 
@@ -148,7 +153,8 @@ final class SchemaMerger implements SchemaMergerInterface
     public function exportSchema(
         SchemaTemplateInterface $rootSchemaTemplate,
         bool $prefixWithNamespace = false,
-        bool $useTemplateName = false
+        bool $useTemplateName = false,
+        bool $optimizeSubSchemaNamespaces = false
     ): void {
         $rootSchemaDefinition = $this->transformExportSchemaDefinition(
             json_decode($rootSchemaTemplate->getSchemaDefinition(), true)
@@ -170,7 +176,13 @@ final class SchemaMerger implements SchemaMergerInterface
             mkdir($this->getOutputDirectory());
         }
 
+        /** @var string $fileContents */
         $fileContents = json_encode($rootSchemaDefinition);
+
+        if (true === $optimizeSubSchemaNamespaces) {
+            $embeddedSchemaNamespace = $rootSchemaDefinition['namespace'] . '.';
+            $fileContents = str_replace($embeddedSchemaNamespace, '', $fileContents);
+        }
 
         file_put_contents($this->getOutputDirectory() . '/' . $schemaFilename, $fileContents);
     }


### PR DESCRIPTION
When we parse schema that has the embedded schema and their namespaces are the same, currently namespace will exist in type when schema is merged, but if you parse that merged schema and send it to the schema registry, `AvroSchema::parse($definition)` will exclude that namespace from type.

Example:

Root **root.level.entity.schema-value.avsc**
```
{
  "type": "record",
  "name": "schema",
  "namespace": "root.level.entity",
  "schema_level": "root",
  "fields": [
    {
      "name": "rootField1",
      "type": "root.level.entity.embeddedSchema"
    },
    {
      "name": "rootField2",
      "type": ["null","root.level.entity.embeddedSchema"],
      "default": null
    }
  ]
}
```

Embedded **root.level.entity.embeddedSchema.avsc**
```
{
  "type": "record",
  "name": "embeddedSchema",
  "namespace": "root.level.entity",
  "fields": [
    {
      "name": "embeddedField",
      "type": ["null","string"],
      "default": null
    }
  ]
}
```

When this kind of schema is merged it will result in having `"type": "root.level.entity.embeddedSchema"` but when parsed and sent to the registry it will have `"type": "embeddedSchema"`

I guess that this should be a part of --optimizeSubSchemaNamespaces option since it also excludes namespaces

@nick-zh what do you think?