### PR TITLE
Added option to optimize primitive schemas before exporting them to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This library enables you to:
 - The library is able to generate avsc schema from PHP classes
 
 ### Merging subschemas / schemas
-Schema template directories: directories containing avsc template files (with subschema)  
-Output directory: output directory for the merged schema files  
+Schema template directories: directories containing avsc template files (with subschema)
+Output directory: output directory for the merged schema files
 
 **Console example**
 ```bash
@@ -44,13 +44,14 @@ $merger->merge();
 ### Merge optimizers
 There are optimizers that you can enable for merging schema:  
 - FullNameOptimizer: removes unneeded namespaces
-- FieldOrderOptimizer: the first fields of a record schema will be: type, name, namespace (if present)  
+- FieldOrderOptimizer: the first fields of a record schema will be: type, name, namespace (if present)
+- PrimitiveSchemaOptimizer: Optimizes primitive schema e.g. `{"type": "string"}` to `"string"`
 
-How to enable optimizer:  
+How to enable optimizer:
 
 **Console example**
 ```bash
-./vendor/bin/avro-cli --optimizeFullNames --optimizeFieldOrder avro:subschema:merge ./example/schemaTemplates ./example/schema
+./vendor/bin/avro-cli --optimizeFullNames --optimizeFieldOrder --optimizePrimitiveSchemas avro:subschema:merge ./example/schemaTemplates ./example/schema
 ```
 **PHP Example**
 ```php
@@ -60,6 +61,7 @@ use PhpKafka\PhpAvroSchemaGenerator\Registry\SchemaRegistry;
 use PhpKafka\PhpAvroSchemaGenerator\Merger\SchemaMerger;
 use PhpKafka\PhpAvroSchemaGenerator\Optimizer\FieldOrderOptimizer;
 use PhpKafka\PhpAvroSchemaGenerator\Optimizer\FullNameOptimizer;
+use PhpKafka\PhpAvroSchemaGenerator\Optimizer\PrimitiveSchemaOptimizer;
 
 $registry = (new SchemaRegistry())
     ->addSchemaTemplateDirectory('./schemaTemplates')
@@ -68,6 +70,7 @@ $registry = (new SchemaRegistry())
 $merger = new SchemaMerger($registry, './schema');
 $merger->addOptimizer(new FieldOrderOptimizer());
 $merger->addOptimizer(new FullNameOptimizer());
+$merger->addOptimizer(new PrimitiveSchemaOptimizer());
 
 $merger->merge();
 
@@ -104,6 +107,6 @@ $generator->exportSchemas($schemas);
 
 ## Disclaimer
 In `v1.3.0` the option `--optimizeSubSchemaNamespaces` was added. It was not working fully  
-in the `1.x` version and we had some discussions (#13) about it.  
+in the `1.x` version and we had some discussions ([#13](https://github.com/php-kafka/php-avro-schema-generator/issues/13)) about it.  
 Ultimately the decision was to adapt this behaviour fully in `v2.0.0` so you might want to  
 upgrade if you rely on that behaviour.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This library enables you to:
 - The library is able to generate avsc schema from PHP classes
 
 ### Merging subschemas / schemas
-Schema template directories: directories containing avsc template files (with subschema)
-Output directory: output directory for the merged schema files
+Schema template directories: directories containing avsc template files (with subschema)  
+Output directory: output directory for the merged schema files  
 
 **Console example**
 ```bash
@@ -47,7 +47,7 @@ There are optimizers that you can enable for merging schema:
 - FieldOrderOptimizer: the first fields of a record schema will be: type, name, namespace (if present)
 - PrimitiveSchemaOptimizer: Optimizes primitive schema e.g. `{"type": "string"}` to `"string"`
 
-How to enable optimizer:
+How to enable optimizer:  
 
 **Console example**
 ```bash

--- a/src/Command/SubSchemaMergeCommand.php
+++ b/src/Command/SubSchemaMergeCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpKafka\PhpAvroSchemaGenerator\Command;
 
-use http\Exception\RuntimeException;
 use PhpKafka\PhpAvroSchemaGenerator\Optimizer\FieldOrderOptimizer;
 use PhpKafka\PhpAvroSchemaGenerator\Optimizer\FullNameOptimizer;
+use PhpKafka\PhpAvroSchemaGenerator\Optimizer\PrimitiveSchemaOptimizer;
 use PhpKafka\PhpAvroSchemaGenerator\Registry\SchemaRegistry;
 use PhpKafka\PhpAvroSchemaGenerator\Merger\SchemaMerger;
 use Symfony\Component\Console\Command\Command;
@@ -21,6 +21,7 @@ class SubSchemaMergeCommand extends Command
     protected $optimizerOptionMapping = [
         'optimizeFieldOrder' => FieldOrderOptimizer::class,
         'optimizeFullNames' => FullNameOptimizer::class,
+        'optimizePrimitiveSchemas' => PrimitiveSchemaOptimizer::class,
     ];
     protected function configure(): void
     {
@@ -76,15 +77,14 @@ class SubSchemaMergeCommand extends Command
         $merger = new SchemaMerger($registry, $outputDirectory);
 
         foreach ($this->optimizerOptionMapping as $optionName => $optimizerClass) {
-            if (true === (bool)$input->getOption($optionName)) {
+            if (true === (bool) $input->getOption($optionName)) {
                 $merger->addOptimizer(new $optimizerClass());
             }
         }
 
         $result = $merger->merge(
             (bool) $input->getOption('prefixWithNamespace'),
-            (bool) $input->getOption('useFilenameAsSchemaName'),
-            (bool) $input->getOption('optimizePrimitiveSchemas')
+            (bool) $input->getOption('useFilenameAsSchemaName')
         );
 
         // retrieve the argument value using getArgument()

--- a/src/Command/SubSchemaMergeCommand.php
+++ b/src/Command/SubSchemaMergeCommand.php
@@ -48,6 +48,12 @@ class SubSchemaMergeCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Remove namespaces if they are enclosed in the same namespace'
+            )
+            ->addOption(
+                'optimizePrimitiveSchemas',
+                null,
+                InputOption::VALUE_NONE,
+                'Optimize primitive schemas with using just type as a schema'
             );
     }
 
@@ -59,7 +65,6 @@ class SubSchemaMergeCommand extends Command
         $templateDirectoryArg = $input->getArgument('templateDirectory');
         /** @var string $outputDirectoryArg */
         $outputDirectoryArg = $input->getArgument('outputDirectory');
-        $optimizeFullNames = (bool)$input->getOption('optimizeFullNames');
 
         $templateDirectory = $this->getPath($templateDirectoryArg);
         $outputDirectory = $this->getPath($outputDirectoryArg);
@@ -78,7 +83,8 @@ class SubSchemaMergeCommand extends Command
 
         $result = $merger->merge(
             (bool) $input->getOption('prefixWithNamespace'),
-            (bool) $input->getOption('useFilenameAsSchemaName')
+            (bool) $input->getOption('useFilenameAsSchemaName'),
+            (bool) $input->getOption('optimizePrimitiveSchemas')
         );
 
         // retrieve the argument value using getArgument()

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -156,7 +156,8 @@ final class SchemaMerger implements SchemaMergerInterface
 
         $prefix = '';
 
-        if (true === $prefixWithNamespace
+        if (
+            true === $prefixWithNamespace
             && false === $rootSchemaTemplate->isPrimitive()
             && is_array($rootSchemaDefinition)
         ) {
@@ -165,7 +166,8 @@ final class SchemaMerger implements SchemaMergerInterface
 
         $schemaFilename = $rootSchemaTemplate->getFilename();
 
-        if (false === $useTemplateName
+        if (
+            false === $useTemplateName
             && false === $rootSchemaTemplate->isPrimitive()
             && is_array($rootSchemaDefinition)
         ) {

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -177,7 +177,7 @@ final class SchemaMerger implements SchemaMergerInterface
     }
 
     /**
-     * @param  mixed $schemaDefinition
+     * @param mixed $schemaDefinition
      * @return mixed
      */
     private function transformExportSchemaDefinition($schemaDefinition)

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -108,13 +108,15 @@ final class SchemaMerger implements SchemaMergerInterface
     /**
      * @param bool $prefixWithNamespace
      * @param bool $useTemplateName
+     * @param bool $optimizePrimitiveSchemas
      * @return integer
      * @throws AvroSchemaParseException
      * @throws SchemaMergerException
      */
     public function merge(
         bool $prefixWithNamespace = false,
-        bool $useTemplateName = false
+        bool $useTemplateName = false,
+        bool $optimizePrimitiveSchemas = false
     ): int {
         $mergedFiles = 0;
         $registry = $this->getSchemaRegistry();
@@ -131,7 +133,7 @@ final class SchemaMerger implements SchemaMergerInterface
             } catch (SchemaMergerException $e) {
                 throw $e;
             }
-            $this->exportSchema($resolvedTemplate, $prefixWithNamespace, $useTemplateName);
+            $this->exportSchema($resolvedTemplate, $prefixWithNamespace, $useTemplateName, $optimizePrimitiveSchemas);
 
             ++$mergedFiles;
         }
@@ -143,12 +145,14 @@ final class SchemaMerger implements SchemaMergerInterface
      * @param SchemaTemplateInterface $rootSchemaTemplate
      * @param boolean                 $prefixWithNamespace
      * @param boolean                 $useTemplateName
+     * @param boolean                 $optimizePrimitiveSchemas
      * @return void
      */
     public function exportSchema(
         SchemaTemplateInterface $rootSchemaTemplate,
         bool $prefixWithNamespace = false,
-        bool $useTemplateName = false
+        bool $useTemplateName = false,
+        bool $optimizePrimitiveSchemas = false
     ): void {
         $rootSchemaDefinition = $this->transformExportSchemaDefinition(
             json_decode($rootSchemaTemplate->getSchemaDefinition(), true, JSON_THROW_ON_ERROR)
@@ -168,6 +172,10 @@ final class SchemaMerger implements SchemaMergerInterface
 
         if (false === file_exists($this->getOutputDirectory())) {
             mkdir($this->getOutputDirectory());
+        }
+
+        if (true === $optimizePrimitiveSchemas && true === $rootSchemaTemplate->isPrimitive()) {
+            $rootSchemaDefinition = $rootSchemaDefinition['type'];
         }
 
         /** @var string $fileContents */

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -156,21 +156,13 @@ final class SchemaMerger implements SchemaMergerInterface
 
         $prefix = '';
 
-        if (
-            true === $prefixWithNamespace
-            && false === $rootSchemaTemplate->isPrimitive()
-            && is_array($rootSchemaDefinition)
-        ) {
+        if (true === $prefixWithNamespace && false === $rootSchemaTemplate->isPrimitive()) {
             $prefix = $rootSchemaDefinition['namespace'] . '.';
         }
 
         $schemaFilename = $rootSchemaTemplate->getFilename();
 
-        if (
-            false === $useTemplateName
-            && false === $rootSchemaTemplate->isPrimitive()
-            && is_array($rootSchemaDefinition)
-        ) {
+        if (false === $useTemplateName && false === $rootSchemaTemplate->isPrimitive()) {
             $schemaFilename = $prefix . $rootSchemaDefinition['name'] . '.' . Avro::FILE_EXTENSION;
         }
 
@@ -185,10 +177,10 @@ final class SchemaMerger implements SchemaMergerInterface
     }
 
     /**
-     * @param  string|array<string,mixed> $schemaDefinition
-     * @return string|array<string,mixed>
+     * @param  mixed $schemaDefinition
+     * @return mixed
      */
-    public function transformExportSchemaDefinition($schemaDefinition)
+    private function transformExportSchemaDefinition($schemaDefinition)
     {
         if (is_array($schemaDefinition)) {
             unset($schemaDefinition['schema_level']);

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -108,15 +108,13 @@ final class SchemaMerger implements SchemaMergerInterface
     /**
      * @param bool $prefixWithNamespace
      * @param bool $useTemplateName
-     * @param bool $optimizePrimitiveSchemas
      * @return integer
      * @throws AvroSchemaParseException
      * @throws SchemaMergerException
      */
     public function merge(
         bool $prefixWithNamespace = false,
-        bool $useTemplateName = false,
-        bool $optimizePrimitiveSchemas = false
+        bool $useTemplateName = false
     ): int {
         $mergedFiles = 0;
         $registry = $this->getSchemaRegistry();
@@ -133,7 +131,7 @@ final class SchemaMerger implements SchemaMergerInterface
             } catch (SchemaMergerException $e) {
                 throw $e;
             }
-            $this->exportSchema($resolvedTemplate, $prefixWithNamespace, $useTemplateName, $optimizePrimitiveSchemas);
+            $this->exportSchema($resolvedTemplate, $prefixWithNamespace, $useTemplateName);
 
             ++$mergedFiles;
         }
@@ -145,14 +143,12 @@ final class SchemaMerger implements SchemaMergerInterface
      * @param SchemaTemplateInterface $rootSchemaTemplate
      * @param boolean                 $prefixWithNamespace
      * @param boolean                 $useTemplateName
-     * @param boolean                 $optimizePrimitiveSchemas
      * @return void
      */
     public function exportSchema(
         SchemaTemplateInterface $rootSchemaTemplate,
         bool $prefixWithNamespace = false,
-        bool $useTemplateName = false,
-        bool $optimizePrimitiveSchemas = false
+        bool $useTemplateName = false
     ): void {
         $rootSchemaDefinition = $this->transformExportSchemaDefinition(
             json_decode($rootSchemaTemplate->getSchemaDefinition(), true, JSON_THROW_ON_ERROR)
@@ -172,10 +168,6 @@ final class SchemaMerger implements SchemaMergerInterface
 
         if (false === file_exists($this->getOutputDirectory())) {
             mkdir($this->getOutputDirectory());
-        }
-
-        if (true === $optimizePrimitiveSchemas && true === $rootSchemaTemplate->isPrimitive()) {
-            $rootSchemaDefinition = $rootSchemaDefinition['type'];
         }
 
         /** @var string $fileContents */

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -8,6 +8,7 @@ use AvroSchemaParseException;
 use PhpKafka\PhpAvroSchemaGenerator\Avro\Avro;
 use PhpKafka\PhpAvroSchemaGenerator\Exception\SchemaMergerException;
 use PhpKafka\PhpAvroSchemaGenerator\Optimizer\OptimizerInterface;
+use PhpKafka\PhpAvroSchemaGenerator\Optimizer\PrimitiveSchemaOptimizer;
 use PhpKafka\PhpAvroSchemaGenerator\Registry\SchemaRegistryInterface;
 use PhpKafka\PhpAvroSchemaGenerator\Schema\SchemaTemplateInterface;
 
@@ -125,7 +126,12 @@ final class SchemaMerger implements SchemaMergerInterface
                 $resolvedTemplate = $this->getResolvedSchemaTemplate($rootSchemaTemplate);
                 foreach ($this->optimizers as $optimizer) {
                     $resolvedTemplate = $resolvedTemplate->withSchemaDefinition(
-                        $optimizer->optimize($resolvedTemplate->getSchemaDefinition())
+                        $optimizer instanceof PrimitiveSchemaOptimizer ?
+                            $optimizer->optimize(
+                                $resolvedTemplate->getSchemaDefinition(),
+                                $resolvedTemplate->isPrimitive()
+                            ) :
+                            $optimizer->optimize($resolvedTemplate->getSchemaDefinition())
                     );
                 }
             } catch (SchemaMergerException $e) {

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -156,13 +156,19 @@ final class SchemaMerger implements SchemaMergerInterface
 
         $prefix = '';
 
-        if (true === $prefixWithNamespace && false === $rootSchemaTemplate->isPrimitive()) {
+        if (true === $prefixWithNamespace
+            && false === $rootSchemaTemplate->isPrimitive()
+            && is_array($rootSchemaDefinition)
+        ) {
             $prefix = $rootSchemaDefinition['namespace'] . '.';
         }
 
         $schemaFilename = $rootSchemaTemplate->getFilename();
 
-        if (false === $useTemplateName && false === $rootSchemaTemplate->isPrimitive()) {
+        if (false === $useTemplateName
+            && false === $rootSchemaTemplate->isPrimitive()
+            && is_array($rootSchemaDefinition)
+        ) {
             $schemaFilename = $prefix . $rootSchemaDefinition['name'] . '.' . Avro::FILE_EXTENSION;
         }
 
@@ -177,12 +183,14 @@ final class SchemaMerger implements SchemaMergerInterface
     }
 
     /**
-     * @param  array<string,mixed> $schemaDefinition
-     * @return array<string,mixed>
+     * @param  string|array<string,mixed> $schemaDefinition
+     * @return string|array<string,mixed>
      */
-    public function transformExportSchemaDefinition(array $schemaDefinition): array
+    public function transformExportSchemaDefinition($schemaDefinition)
     {
-        unset($schemaDefinition['schema_level']);
+        if (is_array($schemaDefinition)) {
+            unset($schemaDefinition['schema_level']);
+        }
 
         return $schemaDefinition;
     }

--- a/src/Merger/SchemaMergerInterface.php
+++ b/src/Merger/SchemaMergerInterface.php
@@ -39,10 +39,10 @@ interface SchemaMergerInterface
     public function exportSchema(SchemaTemplateInterface $rootRootSchemaTemplate): void;
 
     /**
-     * @param  array<string,mixed> $schemaDefinition
-     * @return array<string,mixed>
+     * @param  string|array<string,mixed> $schemaDefinition
+     * @return string|array<string,mixed>
      */
-    public function transformExportSchemaDefinition(array $schemaDefinition): array;
+    public function transformExportSchemaDefinition($schemaDefinition);
 
     /**
      * @param OptimizerInterface $optimizer

--- a/src/Merger/SchemaMergerInterface.php
+++ b/src/Merger/SchemaMergerInterface.php
@@ -39,12 +39,6 @@ interface SchemaMergerInterface
     public function exportSchema(SchemaTemplateInterface $rootRootSchemaTemplate): void;
 
     /**
-     * @param  string|array<string,mixed> $schemaDefinition
-     * @return string|array<string,mixed>
-     */
-    public function transformExportSchemaDefinition($schemaDefinition);
-
-    /**
      * @param OptimizerInterface $optimizer
      */
     public function addOptimizer(OptimizerInterface $optimizer): void;

--- a/src/Optimizer/AbstractOptimizer.php
+++ b/src/Optimizer/AbstractOptimizer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpKafka\PhpAvroSchemaGenerator\Optimizer;
 
-use PhpKafka\PhpAvroSchemaGenerator\Schema\SchemaTemplate;
-
 abstract class AbstractOptimizer
 {
     /**
@@ -91,16 +89,5 @@ abstract class AbstractOptimizer
     protected function typeIsString($data): bool
     {
         return isset($data['type']) && true === is_string($data['type']);
-    }
-
-    /**
-     * @param array|mixed $data
-     * @return bool
-     */
-    protected function isPrimitive($data): bool
-    {
-        return 1 === count($data)
-            && true === isset($data['type'])
-            && array_key_exists($data['type'], SchemaTemplate::AVRO_PRIMITIVE_TYPES);
     }
 }

--- a/src/Optimizer/AbstractOptimizer.php
+++ b/src/Optimizer/AbstractOptimizer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpKafka\PhpAvroSchemaGenerator\Optimizer;
 
+use PhpKafka\PhpAvroSchemaGenerator\Schema\SchemaTemplate;
+
 abstract class AbstractOptimizer
 {
     /**
@@ -89,5 +91,16 @@ abstract class AbstractOptimizer
     protected function typeIsString($data): bool
     {
         return isset($data['type']) && true === is_string($data['type']);
+    }
+
+    /**
+     * @param array|mixed $data
+     * @return bool
+     */
+    protected function isPrimitive($data): bool
+    {
+        return 1 === count($data)
+            && true === isset($data['type'])
+            && array_key_exists($data['type'], SchemaTemplate::AVRO_PRIMITIVE_TYPES);
     }
 }

--- a/src/Optimizer/PrimitiveSchemaOptimizer.php
+++ b/src/Optimizer/PrimitiveSchemaOptimizer.php
@@ -11,8 +11,12 @@ class PrimitiveSchemaOptimizer extends AbstractOptimizer implements OptimizerInt
      * @return string
      * @throws \JsonException
      */
-    public function optimize(string $definition): string
+    public function optimize(string $definition, bool $isPrimitive = false): string
     {
+        if (false === $isPrimitive) {
+            return $definition;
+        }
+
         $data = json_decode($definition, true, JSON_THROW_ON_ERROR);
 
         $data = $this->processSchema($data);
@@ -21,12 +25,12 @@ class PrimitiveSchemaOptimizer extends AbstractOptimizer implements OptimizerInt
     }
 
     /**
-     * @param array|mixed $data
-     * @return array|mixed
+     * @param mixed $data
+     * @return mixed
      */
     private function processSchema($data)
     {
-        if (true === $this->isPrimitive($data)) {
+        if (true === isset($data['type'])) {
             $data = $data['type'];
         }
 

--- a/src/Optimizer/PrimitiveSchemaOptimizer.php
+++ b/src/Optimizer/PrimitiveSchemaOptimizer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpKafka\PhpAvroSchemaGenerator\Optimizer;
+
+class PrimitiveSchemaOptimizer extends AbstractOptimizer implements OptimizerInterface
+{
+    /**
+     * @param string $definition
+     * @return string
+     * @throws \JsonException
+     */
+    public function optimize(string $definition): string
+    {
+        $data = json_decode($definition, true, JSON_THROW_ON_ERROR);
+
+        $data = $this->processSchema($data);
+
+        return json_encode($data, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array|mixed $data
+     * @return array|mixed
+     */
+    private function processSchema($data)
+    {
+        if (true === $this->isPrimitive($data)) {
+            $data = $data['type'];
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/SchemaTemplate.php
+++ b/src/Schema/SchemaTemplate.php
@@ -129,7 +129,7 @@ final class SchemaTemplate implements SchemaTemplateInterface
     {
         $fields = json_decode($this->getSchemaDefinition(), true, JSON_THROW_ON_ERROR);
 
-        if (is_string($fields) && array_key_exists($fields, self::AVRO_PRIMITIVE_TYPES)) {
+        if (is_string($fields) && true === isset(self::AVRO_PRIMITIVE_TYPES[$fields])) {
             return true;
         }
 

--- a/src/Schema/SchemaTemplate.php
+++ b/src/Schema/SchemaTemplate.php
@@ -129,6 +129,10 @@ final class SchemaTemplate implements SchemaTemplateInterface
     {
         $fields = json_decode($this->getSchemaDefinition(), true, JSON_THROW_ON_ERROR);
 
+        if (is_string($fields) && array_key_exists($fields, self::AVRO_PRIMITIVE_TYPES)) {
+            return true;
+        }
+
         if (true === isset($fields['type'])) {
             return array_key_exists($fields['type'], self::AVRO_PRIMITIVE_TYPES);
         }

--- a/tests/Unit/Merger/SchemaMergerTest.php
+++ b/tests/Unit/Merger/SchemaMergerTest.php
@@ -498,36 +498,6 @@ class SchemaMergerTest extends TestCase
         unlink('/tmp/test.avsc');
     }
 
-    public function testExportSchemaWithOptimizePrimitiveSchemasOption()
-    {
-        $expectedSchema = '"string"';
-
-        $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
-        $schemaTemplate
-            ->expects(self::once())
-            ->method('getSchemaDefinition')
-            ->willReturn('{"type": "string"}');
-        $schemaTemplate
-            ->expects(self::exactly(2))
-            ->method('isPrimitive')
-            ->willReturn(true);
-        $schemaTemplate
-            ->expects(self::once())
-            ->method('getFilename')
-            ->willReturn('test.avsc');
-        $schemaRegistry = $this->getMockForAbstractClass(SchemaRegistryInterface::class);
-
-        $merger = new SchemaMerger($schemaRegistry);
-        $merger->exportSchema($schemaTemplate, false, false, true);
-
-        file_put_contents('/tmp/test_optimized_primitive_schema.avsc', $expectedSchema);
-
-        self::assertFileExists('/tmp/test.avsc');
-        self::assertFileEquals('/tmp/test_optimized_primitive_schema.avsc', '/tmp/test.avsc');
-        unlink('/tmp/test_optimized_primitive_schema.avsc');
-        unlink('/tmp/test.avsc');
-    }
-
     public function testExportSchemaPrimitiveWithWrongOptions()
     {
         $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);

--- a/tests/Unit/Merger/SchemaMergerTest.php
+++ b/tests/Unit/Merger/SchemaMergerTest.php
@@ -498,6 +498,36 @@ class SchemaMergerTest extends TestCase
         unlink('/tmp/test.avsc');
     }
 
+    public function testExportSchemaWithOptimizePrimitiveSchemasOption()
+    {
+        $expectedSchema = '"string"';
+
+        $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
+        $schemaTemplate
+            ->expects(self::once())
+            ->method('getSchemaDefinition')
+            ->willReturn('{"type": "string"}');
+        $schemaTemplate
+            ->expects(self::exactly(2))
+            ->method('isPrimitive')
+            ->willReturn(true);
+        $schemaTemplate
+            ->expects(self::once())
+            ->method('getFilename')
+            ->willReturn('test.avsc');
+        $schemaRegistry = $this->getMockForAbstractClass(SchemaRegistryInterface::class);
+
+        $merger = new SchemaMerger($schemaRegistry);
+        $merger->exportSchema($schemaTemplate, false, false, true);
+
+        file_put_contents('/tmp/test_optimized_primitive_schema.avsc', $expectedSchema);
+
+        self::assertFileExists('/tmp/test.avsc');
+        self::assertFileEquals('/tmp/test_optimized_primitive_schema.avsc', '/tmp/test.avsc');
+        unlink('/tmp/test_optimized_primitive_schema.avsc');
+        unlink('/tmp/test.avsc');
+    }
+
     public function testExportSchemaPrimitiveWithWrongOptions()
     {
         $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);

--- a/tests/Unit/Optimizer/PrimitiveSchemaOptimizerTest.php
+++ b/tests/Unit/Optimizer/PrimitiveSchemaOptimizerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpKafka\PhpAvroSchemaGenerator\Tests\Unit\Optimizer;
+
+use PhpKafka\PhpAvroSchemaGenerator\Optimizer\PrimitiveSchemaOptimizer;
+use PHPUnit\Framework\TestCase;
+
+class PrimitiveSchemaOptimizerTest extends TestCase
+{
+    public function testOptimize(): void
+    {
+        $schema = '{"type": "string"}';
+
+        $expectedResult = json_encode(json_decode('"string"'));
+
+        $optimizer = new PrimitiveSchemaOptimizer();
+
+        self::assertEquals($expectedResult, $optimizer->optimize($schema));
+    }
+}

--- a/tests/Unit/Optimizer/PrimitiveSchemaOptimizerTest.php
+++ b/tests/Unit/Optimizer/PrimitiveSchemaOptimizerTest.php
@@ -17,6 +17,28 @@ class PrimitiveSchemaOptimizerTest extends TestCase
 
         $optimizer = new PrimitiveSchemaOptimizer();
 
-        self::assertEquals($expectedResult, $optimizer->optimize($schema));
+        self::assertEquals($expectedResult, $optimizer->optimize($schema, true));
+    }
+
+    public function testOptimizeForStringSchema(): void
+    {
+        $schema = '"string"';
+
+        $expectedResult = json_encode(json_decode('"string"'));
+
+        $optimizer = new PrimitiveSchemaOptimizer();
+
+        self::assertEquals($expectedResult, $optimizer->optimize($schema, true));
+    }
+
+    public function testOptimizeForRecordSchema(): void
+    {
+        $schema = '{"type":"record","namespace":"com.example","name":"Book","fields":[{"name":"isbn","type":"string"}]}';
+
+        $expectedResult = json_encode(json_decode($schema));
+
+        $optimizer = new PrimitiveSchemaOptimizer();
+
+        self::assertEquals($expectedResult, $optimizer->optimize($schema, false));
     }
 }

--- a/tests/Unit/Schema/SchemaTemplateTest.php
+++ b/tests/Unit/Schema/SchemaTemplateTest.php
@@ -49,20 +49,34 @@ class SchemaTemplateTest extends TestCase
     {
         $template = (new SchemaTemplate())->withSchemaDefinition('{"type":"string"}');
 
-        self::assertTrue($template->isPrimitive($template));
+        self::assertTrue($template->isPrimitive());
     }
 
     public function testIsPrimitiveFalse()
     {
         $template = (new SchemaTemplate())->withSchemaDefinition('{"type":"record"}');
 
-        self::assertFalse($template->isPrimitive($template));
+        self::assertFalse($template->isPrimitive());
+    }
+
+    public function testIsPrimitiveTrueForOptimizedSchema()
+    {
+        $template = (new SchemaTemplate())->withSchemaDefinition('"string"');
+
+        self::assertTrue($template->isPrimitive());
+    }
+
+    public function testIsPrimitiveFalseForOptimizedSchema()
+    {
+        $template = (new SchemaTemplate())->withSchemaDefinition('"foo"');
+
+        self::assertFalse($template->isPrimitive());
     }
 
     public function testIsPrimitiveFalseOnMissingType()
     {
         $template = (new SchemaTemplate())->withSchemaDefinition('{"foo":"bar"}');
 
-        self::assertFalse($template->isPrimitive($template));
+        self::assertFalse($template->isPrimitive());
     }
 }


### PR DESCRIPTION
Schema registry supports two ways of defining primitive schemas:

`{"type": "string"}`

and:

`"string"`

Which are equivalent according to [Avro specification](https://avro.apache.org/docs/current/spec.html#schema_primitive).

So, I added option to enable that behaviour by passing `--optimizePrimitiveSchemas` option.