### PR TITLE
json_encode with preserve zero fraction flag

### DIFF
--- a/src/Generator/SchemaGenerator.php
+++ b/src/Generator/SchemaGenerator.php
@@ -89,7 +89,7 @@ final class SchemaGenerator implements SchemaGeneratorInterface
                 $namespace = $schema['namespace'] . '.' . $schema['name'];
             }
 
-            $schemas[$namespace] = json_encode($schema);
+            $schemas[$namespace] = json_encode($schema, JSON_PRESERVE_ZERO_FRACTION);
         }
 
         return $schemas;

--- a/src/Merger/SchemaMerger.php
+++ b/src/Merger/SchemaMerger.php
@@ -192,7 +192,7 @@ final class SchemaMerger implements SchemaMergerInterface
         }
 
         /** @var string $fileContents */
-        $fileContents = json_encode($rootSchemaDefinition);
+        $fileContents = json_encode($rootSchemaDefinition, JSON_PRESERVE_ZERO_FRACTION);
 
         file_put_contents($this->getOutputDirectory() . '/' . $schemaFilename, $fileContents);
     }

--- a/src/Optimizer/FieldOrderOptimizer.php
+++ b/src/Optimizer/FieldOrderOptimizer.php
@@ -19,7 +19,9 @@ class FieldOrderOptimizer extends AbstractOptimizer implements OptimizerInterfac
 
         $data = $this->processSchema($data);
 
-        return $schemaTemplate->withSchemaDefinition(json_encode($data, JSON_THROW_ON_ERROR));
+        return $schemaTemplate->withSchemaDefinition(
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION)
+        );
     }
 
     /**

--- a/src/Optimizer/FullNameOptimizer.php
+++ b/src/Optimizer/FullNameOptimizer.php
@@ -20,7 +20,9 @@ class FullNameOptimizer extends AbstractOptimizer implements OptimizerInterface
         $currentNamespace = $data['namespace'] ?? '';
         $data = $this->processSchema($currentNamespace, $data, true);
 
-        return $schemaTemplate->withSchemaDefinition(json_encode($data, JSON_THROW_ON_ERROR));
+        return $schemaTemplate->withSchemaDefinition(
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION)
+        );
     }
 
     /**

--- a/src/Optimizer/PrimitiveSchemaOptimizer.php
+++ b/src/Optimizer/PrimitiveSchemaOptimizer.php
@@ -23,7 +23,9 @@ class PrimitiveSchemaOptimizer extends AbstractOptimizer implements OptimizerInt
 
         $data = $this->processSchema($data);
 
-        return $schemaTemplate->withSchemaDefinition(json_encode($data, JSON_THROW_ON_ERROR));
+        return $schemaTemplate->withSchemaDefinition(
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION)
+        );
     }
 
     /**

--- a/tests/Unit/Generator/SchemaGeneratorTest.php
+++ b/tests/Unit/Generator/SchemaGeneratorTest.php
@@ -54,26 +54,26 @@ class SchemaGeneratorTest extends TestCase
                     ],
                     [
                         'name' => 'name',
-                        'type' => 'double',
-                        'default' => 0.0,
+                        'type' => 'string',
+                        'default' => 'test',
                         'doc' => 'test',
                         'logicalType' => 'test'
                     ]
                 ]
-            ], JSON_PRESERVE_ZERO_FRACTION),
+            ]),
             'Test2Class' => json_encode([
                 'type' => 'record',
                 'name' => 'Test2Class',
                 'fields' => [
                     [
                         'name' => 'name',
-                        'type' => 'double',
-                        'default' => 0.0,
+                        'type' => 'string',
+                        'default' => 'test',
                         'doc' => 'test',
                         'logicalType' => 'test'
                     ]
                 ]
-            ], JSON_PRESERVE_ZERO_FRACTION)
+            ])
         ];
 
         $property1 = $this->getMockForAbstractClass(PhpClassPropertyInterface::class);
@@ -82,9 +82,9 @@ class SchemaGeneratorTest extends TestCase
         $property1->expects(self::exactly(1))->method('getPropertyDefault')->willReturn(PhpClassPropertyInterface::NO_DEFAULT);
 
         $property2 = $this->getMockForAbstractClass(PhpClassPropertyInterface::class);
-        $property2->expects(self::exactly(2))->method('getPropertyType')->willReturn('double');
+        $property2->expects(self::exactly(2))->method('getPropertyType')->willReturn('string');
         $property2->expects(self::exactly(2))->method('getPropertyName')->willReturn('name');
-        $property2->expects(self::exactly(4))->method('getPropertyDefault')->willReturn(0.0);
+        $property2->expects(self::exactly(4))->method('getPropertyDefault')->willReturn('test');
         $property2->expects(self::exactly(6))->method('getPropertyDoc')->willReturn('test');
         $property2->expects(self::exactly(4))->method('getPropertyLogicalType')->willReturn('test');
 

--- a/tests/Unit/Generator/SchemaGeneratorTest.php
+++ b/tests/Unit/Generator/SchemaGeneratorTest.php
@@ -54,26 +54,26 @@ class SchemaGeneratorTest extends TestCase
                     ],
                     [
                         'name' => 'name',
-                        'type' => 'string',
-                        'default' => 'test',
+                        'type' => 'double',
+                        'default' => 0.0,
                         'doc' => 'test',
                         'logicalType' => 'test'
                     ]
                 ]
-            ]),
+            ], JSON_PRESERVE_ZERO_FRACTION),
             'Test2Class' => json_encode([
                 'type' => 'record',
                 'name' => 'Test2Class',
                 'fields' => [
                     [
                         'name' => 'name',
-                        'type' => 'string',
-                        'default' => 'test',
+                        'type' => 'double',
+                        'default' => 0.0,
                         'doc' => 'test',
                         'logicalType' => 'test'
                     ]
                 ]
-            ])
+            ], JSON_PRESERVE_ZERO_FRACTION)
         ];
 
         $property1 = $this->getMockForAbstractClass(PhpClassPropertyInterface::class);
@@ -82,9 +82,9 @@ class SchemaGeneratorTest extends TestCase
         $property1->expects(self::exactly(1))->method('getPropertyDefault')->willReturn(PhpClassPropertyInterface::NO_DEFAULT);
 
         $property2 = $this->getMockForAbstractClass(PhpClassPropertyInterface::class);
-        $property2->expects(self::exactly(2))->method('getPropertyType')->willReturn('string');
+        $property2->expects(self::exactly(2))->method('getPropertyType')->willReturn('double');
         $property2->expects(self::exactly(2))->method('getPropertyName')->willReturn('name');
-        $property2->expects(self::exactly(4))->method('getPropertyDefault')->willReturn('test');
+        $property2->expects(self::exactly(4))->method('getPropertyDefault')->willReturn(0.0);
         $property2->expects(self::exactly(6))->method('getPropertyDoc')->willReturn('test');
         $property2->expects(self::exactly(4))->method('getPropertyLogicalType')->willReturn('test');
 
@@ -107,6 +107,48 @@ class SchemaGeneratorTest extends TestCase
         $result = $generator->generate();
         self::assertEquals($expectedResult, $result);
         self::assertCount(2, $result);
+    }
+
+    public function testGeneratePreservesZeroFraction()
+    {
+        $expectedResult = [
+            'name.space.TestClass' => json_encode([
+                'type' => 'record',
+                'name' => 'TestClass',
+                'namespace' => 'name.space',
+                'fields' => [
+                    [
+                        'name' => 'name',
+                        'type' => 'double',
+                        'default' => 0.0,
+                        'doc' => 'test',
+                        'logicalType' => 'test'
+                    ]
+                ]
+            ], JSON_PRESERVE_ZERO_FRACTION)
+        ];
+
+        $property = $this->getMockForAbstractClass(PhpClassPropertyInterface::class);
+        $property->expects(self::exactly(1))->method('getPropertyType')->willReturn('double');
+        $property->expects(self::exactly(1))->method('getPropertyName')->willReturn('name');
+        $property->expects(self::exactly(2))->method('getPropertyDefault')->willReturn(0.0);
+        $property->expects(self::exactly(3))->method('getPropertyDoc')->willReturn('test');
+        $property->expects(self::exactly(2))->method('getPropertyLogicalType')->willReturn('test');
+
+
+        $class = $this->getMockForAbstractClass(PhpClassInterface::class);
+        $class->expects(self::once())->method('getClassName')->willReturn('TestClass');
+        $class->expects(self::exactly(2))->method('getClassNamespace')->willReturn('name\\space');
+        $class->expects(self::once())->method('getClassProperties')->willReturn([$property]);
+
+        $registry = $this->getMockForAbstractClass(ClassRegistryInterface::class);
+        $registry->expects(self::once())->method('getClasses')->willReturn([$class]);
+
+        $generator = new SchemaGenerator();
+        $generator->setClassRegistry($registry);
+        $result = $generator->generate();
+        self::assertEquals($expectedResult, $result);
+        self::assertCount(1, $result);
     }
 
     public function testExportSchemas()

--- a/tests/Unit/Optimizer/FieldOrderOptimizerTest.php
+++ b/tests/Unit/Optimizer/FieldOrderOptimizerTest.php
@@ -48,6 +48,11 @@ class FieldOrderOptimizerTest extends TestCase
                     "default": []
                 },
                 {
+                    "name": "price",
+                    "type": "float",
+                    "default": 99.0
+                },
+                {
                     "name": "foreword",
                     "type": "array",
                     "items": ["null", "com.example.Page"]
@@ -144,6 +149,11 @@ class FieldOrderOptimizerTest extends TestCase
                     "default": []
                 },
                 {
+                    "name": "price",
+                    "type": "float",
+                    "default": 99.0
+                },
+                {
                     "name": "foreword",
                     "type": "array",
                     "items": ["null", "com.example.Page"]
@@ -202,7 +212,7 @@ class FieldOrderOptimizerTest extends TestCase
                     ]
                 }
             ]
-        }'));
+        }'),JSON_PRESERVE_ZERO_FRACTION);
 
         $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);
         $schemaTemplate

--- a/tests/Unit/Optimizer/FullNameOptimizerTest.php
+++ b/tests/Unit/Optimizer/FullNameOptimizerTest.php
@@ -48,6 +48,11 @@ class FullNameOptimizerTest extends TestCase
                     "default": []
                 },
                 {
+                    "name": "price",
+                    "type": "float",
+                    "default": 99.0
+                },
+                {
                     "name": "foreword",
                     "type": "array",
                     "items": ["null","com.example.Page"]
@@ -122,6 +127,11 @@ class FullNameOptimizerTest extends TestCase
                     "default": []
                 },
                 {
+                    "name": "price",
+                    "type": "float",
+                    "default": 99.0
+                },
+                {
                     "name": "foreword",
                     "type": "array",
                     "items": ["null","Page"]
@@ -159,7 +169,7 @@ class FullNameOptimizerTest extends TestCase
                 },
                 { "name": "backSide", "type": "com.example.other.Cover"}
             ]
-        }'));
+        }'), JSON_PRESERVE_ZERO_FRACTION);
 
 
         $schemaTemplate = $this->getMockForAbstractClass(SchemaTemplateInterface::class);


### PR DESCRIPTION
:wave:  unsolicited PR incoming...

We figured out that in some cases the compiled schema drops the floating point because of the json_encode.

```
{
      "name": "score",
      "type": "double",
      "default": 0.0,
}
```


`{"name":"score","type":"double","default":0}`

Adding JSON_PRESERVE_ZERO_FRACTION to json_encode fixes the issue. Would love to hear some feedback if you think this is ok.